### PR TITLE
[L33T-1607] Notes modal disappear after pressing the enter key - fix

### DIFF
--- a/react/features/notes/components/NotesDialog.web.js
+++ b/react/features/notes/components/NotesDialog.web.js
@@ -166,6 +166,7 @@ class NotesDialog extends Component<Props, State> {
         return (
             <Dialog
                 customHeader = { NotesDialogHeader }
+                disableEnter = { true }
                 hideCancelButton = { true }
                 onCancel = { this._onCancel }
                 submitDisabled = { true }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
